### PR TITLE
Separating DoWork into 2 methods

### DIFF
--- a/IWorker.go
+++ b/IWorker.go
@@ -6,9 +6,11 @@ type IWorker interface {
 	GetGUID() string
 	// add a message to this workers queue
 	QueueMessage(MapMessage)
+	// process all queued messsages
+	ProcessMessages()
 	// attache the AutoMPI.Node.Send(func(MapMessage)) method to this worker
 	AttachSendMethod(func(MapMessage))
-	// do work, passing the nanoseconds since the last call
+	// do work
 	DoWork()
 	// close the worker
 	Close()

--- a/Node-WorkerMethods.go
+++ b/Node-WorkerMethods.go
@@ -19,6 +19,17 @@ func (base *Node) workerWorkLoop() {
 		}
 	}
 }
+func (base *Node) workerProcessMessagesLoop() {
+	for {
+		if len(base.workers) > 0 {
+			for _, value := range base.workers {
+				value.ProcessMessages()
+			}
+		} else {
+			time.Sleep(secondsToSleepIfNoWorkers * time.Second)
+		}
+	}
+}
 
 // AttachWorker to the node
 // AttachSendMethod to enable Sending of messages

--- a/Node.go
+++ b/Node.go
@@ -86,6 +86,7 @@ func CreateNode(
 
 	base.WorkersWorking = true
 	go base.workerWorkLoop()
+	go base.workerProcessMessagesLoop()
 	fmt.Println("Workers gorutine started")
 
 	go base.stateServe()

--- a/WorkerExampleIPCamera.go
+++ b/WorkerExampleIPCamera.go
@@ -33,18 +33,18 @@ func CreateWorkerExampleIPCamera(workerGUID string, sourceURL string) IWorker {
 	return worker
 }
 
-// DoWork do the work of the worker
-func (base *WorkerExampleIPCamera) DoWork() {
-
+// ProcessMessages process all messages for this worker
+func (base *WorkerExampleIPCamera) ProcessMessages() {
 	for len(base.MessageList) > 0 {
 		Message := base.MessageList[0]
 		base.MessageList = base.MessageList[1:]
-
 		Message.DestinationGUID = ""
-
 		// Process Message
 	}
+}
 
+// DoWork do the work of the worker
+func (base *WorkerExampleIPCamera) DoWork() {
 	res, err := http.Get(base.sourceURL)
 	if err != nil {
 		log.Fatal(err)

--- a/WorkerExampleKeyValueStore.go
+++ b/WorkerExampleKeyValueStore.go
@@ -27,8 +27,8 @@ func CreateWorkerExampleKeyValueStore(workerGUID string) IWorker {
 	return worker
 }
 
-// DoWork do the work of the worker
-func (base *WorkerExampleKeyValueStore) DoWork() {
+// ProcessMessages process all messages for this worker
+func (base *WorkerExampleKeyValueStore) ProcessMessages() {
 
 	for len(base.MessageList) > 0 {
 		Message := base.MessageList[0]
@@ -50,7 +50,7 @@ func (base *WorkerExampleKeyValueStore) DoWork() {
 			break
 		case "set":
 			base.DataStored[Message.GetValue("key")] = Message.GetData()
-			fmt.Printf("%s - Data stored Key:%s\n",base.GUID, Message.GetValue("key"))
+			fmt.Printf("%s - Data stored Key:%s\n", base.GUID, Message.GetValue("key"))
 			break
 		case "delete":
 			_, ok := base.DataStored[Message.GetValue("key")]
@@ -62,6 +62,11 @@ func (base *WorkerExampleKeyValueStore) DoWork() {
 			break
 		}
 	}
+}
+
+// DoWork do the work of the worker
+func (base *WorkerExampleKeyValueStore) DoWork() {
+
 	//	fmt.Println(base.GUID, " - WorkDone")
 	time.Sleep(50 * time.Millisecond)
 }

--- a/WorkerTemplate.go
+++ b/WorkerTemplate.go
@@ -51,17 +51,19 @@ func (base *WorkerTemplate) QueueMessage(Message MapMessage) {
 	base.MessageList = append(base.MessageList, Message)
 }
 
-// DoWork do the work of the worker
-func (base *WorkerTemplate) DoWork() {
-
+// ProcessMessages process all messages for this worker
+func (base *WorkerTemplate) ProcessMessages() {
 	for len(base.MessageList) > 0 {
 		Message := base.MessageList[0]
 		base.MessageList = base.MessageList[1:]
-
 		Message.DestinationGUID = ""
 		// Process Message
 	}
-	//	fmt.Println(base.GUID, " - WorkDone")
+}
+
+// DoWork do the work of the worker
+func (base *WorkerTemplate) DoWork() {
+
 	time.Sleep(50 * time.Millisecond)
 }
 


### PR DESCRIPTION
Separated the DoWork method into DoWork and ProcessMessages. This was done to prevent blocking processing messages if there was a long running work load.