### PR TITLE
Worker Groups

### DIFF
--- a/IWorker.go
+++ b/IWorker.go
@@ -4,6 +4,8 @@ package AutoMPI
 type IWorker interface {
 	// Get the guid of this worker
 	GetGUID() string
+	// Get the group of this worker
+	GetGroup() string
 	// add a message to this workers queue
 	QueueMessage(MapMessage)
 	// process all queued messsages

--- a/MapMessage.go
+++ b/MapMessage.go
@@ -7,10 +7,11 @@ import (
 
 // MapMessage the struct for Messages with Map and []byte
 type MapMessage struct {
-	DestinationGUID string
-	SourceGUID      string
-	Message         map[string]string
-	Data            []byte
+	DestinationGUID  string
+	DestinationGroup string
+	SourceGUID       string
+	Message          map[string]string
+	Data             []byte
 }
 
 // CreateMapMessageEmpty create an empty MapMessage

--- a/MessageKeys.go
+++ b/MessageKeys.go
@@ -17,6 +17,8 @@ const (
 	SystemKeyDetailsWhereIsThisAgent = "AutoMPI_SKD_WhereIsThisAgent"
 	// SystemMessageDataPartGUIDWorker details
 	SystemMessageDataPartGUIDWorker = "AutoMPI_SMDP_GUID_Worker"
+	// SystemMessageDataPartGroupWorker details
+	SystemMessageDataPartGroupWorker = "AutoMPI_SMDP_Group_Worker"
 	// SystemMessageDataPartGUIDNode details
 	SystemMessageDataPartGUIDNode = "AutoMPI_SMDP_GUID_Node"
 	// SystemMessageDataPartHOSTIPEP details

--- a/Node-WorkerMethods.go
+++ b/Node-WorkerMethods.go
@@ -38,7 +38,9 @@ func (base *Node) workerProcessMessagesLoop() {
 func (base *Node) AttachWorker(worker IWorker) {
 	worker.AttachSendMethod(base.Send)
 	base.workers[worker.GetGUID()] = worker
-	base.addLocalWorkerLocation(worker.GetGUID())
+
+	base.LocalWorkersLocation[worker.GetGUID()] = CreateWorkerLocation(worker.GetGUID(), worker.GetGroup(), base.MyNodeGUID)
+	base.LocalWorkersAnnouncingLocation[worker.GetGUID()] = defautNumberOfWorkerLocationAnnouncements
 }
 
 // DetachWorker Close() the worker and remove it from the Node
@@ -54,10 +56,6 @@ func (base *Node) DetachWorker(workerGUID string) {
 	}
 }
 
-func (base *Node) addLocalWorkerLocation(WorkerGUID string) {
-	base.LocalWorkersLocation[WorkerGUID] = CreateWorkerLocation(WorkerGUID, base.MyNodeGUID)
-	base.LocalWorkersAnnouncingLocation[WorkerGUID] = defautNumberOfWorkerLocationAnnouncements
-}
 func (base *Node) removeLocalWorkerLocation(WorkerGUID string) {
 
 	_, ok := base.LocalWorkersLocation[WorkerGUID]
@@ -71,7 +69,7 @@ func (base *Node) isALocalWorker(WorkerGUID string) bool {
 }
 
 func (base *Node) processWorkerLocation(Message MapMessage) {
-	base.AllWorkersLocation[Message.GetValue(SystemMessageDataPartGUIDWorker)] = CreateWorkerLocation(Message.GetValue(SystemMessageDataPartGUIDWorker), Message.GetValue(SystemMessageDataPartGUIDNode))
+	base.AllWorkersLocation[Message.GetValue(SystemMessageDataPartGUIDWorker)] = CreateWorkerLocation(Message.GetValue(SystemMessageDataPartGUIDWorker), Message.GetValue(SystemMessageDataPartGroupWorker), Message.GetValue(SystemMessageDataPartGUIDNode))
 }
 
 func (base *Node) announceAllAgentsInLocalAgentsAnnouncing() {
@@ -83,6 +81,7 @@ func (base *Node) announceAllAgentsInLocalAgentsAnnouncing() {
 	for key, value := range base.LocalWorkersAnnouncingLocation {
 		if value > 0 {
 			TemplateMessage[SystemMessageDataPartGUIDWorker] = key
+			TemplateMessage[SystemMessageDataPartGroupWorker] = base.LocalWorkersLocation[key].Group
 			base.BoardCaster.Boardcast(CreateMapMessage(TemplateMessage))
 			base.LocalWorkersAnnouncingLocation[key]--
 		} else {

--- a/WorkerExampleIPCamera.go
+++ b/WorkerExampleIPCamera.go
@@ -15,6 +15,7 @@ import (
 // WorkerExampleIPCamera example worker
 type WorkerExampleIPCamera struct {
 	GUID        string
+	Group       string
 	CreatedAt   time.Time
 	MessageList []MapMessage
 	Send        func(MapMessage)
@@ -26,6 +27,7 @@ type WorkerExampleIPCamera struct {
 func CreateWorkerExampleIPCamera(workerGUID string, sourceURL string) IWorker {
 	worker := new(WorkerExampleIPCamera)
 	worker.GUID = workerGUID
+	worker.Group = ""
 	worker.sourceURL = sourceURL
 	worker.CreatedAt = time.Now()
 	worker.LastDidWork = time.Now()
@@ -78,6 +80,11 @@ func (base *WorkerExampleIPCamera) DoWork() {
 // GetGUID of the worker
 func (base WorkerExampleIPCamera) GetGUID() string {
 	return base.GUID
+}
+
+// GetGroup of the worker
+func (base WorkerExampleIPCamera) GetGroup() string {
+	return base.Group
 }
 
 // GetAge age of fhe link

--- a/WorkerExampleKeyValueStore.go
+++ b/WorkerExampleKeyValueStore.go
@@ -9,6 +9,7 @@ import (
 // WorkerExampleKeyValueStore template worker
 type WorkerExampleKeyValueStore struct {
 	GUID        string
+	Group       string
 	CreatedAt   time.Time
 	MessageList []MapMessage
 	Send        func(MapMessage)
@@ -20,6 +21,7 @@ type WorkerExampleKeyValueStore struct {
 func CreateWorkerExampleKeyValueStore(workerGUID string) IWorker {
 	worker := new(WorkerExampleKeyValueStore)
 	worker.GUID = workerGUID
+	worker.Group = ""
 	worker.CreatedAt = time.Now()
 	worker.LastDidWork = time.Now()
 	worker.MessageList = make([]MapMessage, 0)
@@ -74,6 +76,11 @@ func (base *WorkerExampleKeyValueStore) DoWork() {
 // GetGUID of the worker
 func (base WorkerExampleKeyValueStore) GetGUID() string {
 	return base.GUID
+}
+
+// GetGroup of the worker
+func (base WorkerExampleKeyValueStore) GetGroup() string {
+	return base.Group
 }
 
 // GetAge age of fhe link

--- a/WorkerLocation.go
+++ b/WorkerLocation.go
@@ -7,15 +7,17 @@ import (
 // WorkerLocation details
 type WorkerLocation struct {
 	GUID              string
+	Group             string
 	CreationTimeStamp time.Time
 	ModifiedTimeStamp time.Time
 	parentNodeGUID    string
 }
 
 // CreateWorkerLocation as it says
-func CreateWorkerLocation(GUID string, parentNodeGUID string) *WorkerLocation {
+func CreateWorkerLocation(GUID string, Group string, parentNodeGUID string) *WorkerLocation {
 	location := new(WorkerLocation)
 	location.GUID = GUID
+	location.Group = Group
 	location.CreationTimeStamp = time.Now()
 	location.ModifiedTimeStamp = time.Now()
 	location.parentNodeGUID = parentNodeGUID

--- a/WorkerTemplate.go
+++ b/WorkerTemplate.go
@@ -9,6 +9,7 @@ import (
 // WorkerTemplate template worker
 type WorkerTemplate struct {
 	GUID        string
+	Group       string
 	CreatedAt   time.Time
 	MessageList []MapMessage
 	Send        func(MapMessage)
@@ -19,6 +20,7 @@ type WorkerTemplate struct {
 func CreateWorkerTemplate(workerGUID string) IWorker {
 	worker := new(WorkerTemplate)
 	worker.GUID = workerGUID
+	worker.Group = ""
 	worker.CreatedAt = time.Now()
 	worker.LastDidWork = time.Now()
 	worker.MessageList = make([]MapMessage, 0)
@@ -28,6 +30,11 @@ func CreateWorkerTemplate(workerGUID string) IWorker {
 // GetGUID of the worker
 func (base WorkerTemplate) GetGUID() string {
 	return base.GUID
+}
+
+// GetGroup of the worker
+func (base WorkerTemplate) GetGroup() string {
+	return base.Group
 }
 
 // GetAge age of fhe link


### PR DESCRIPTION
new code to enable worker groups.

Allows sending to groups defined by the SystemMessageDataPartGroupWorker

each worker still receives a message addressed to their personal GUID not the group ID